### PR TITLE
feat: run function apps from package by default

### DIFF
--- a/modules/node-function-app/locals.tf
+++ b/modules/node-function-app/locals.tf
@@ -1,5 +1,8 @@
 locals {
   app_settings = {
     SCM_DO_BUILD_DURING_DEPLOYMENT = false
+    # run from the zip file
+    # see https://learn.microsoft.com/en-gb/azure/azure-functions/run-functions-from-deployment-package#
+    WEBSITE_RUN_FROM_PACKAGE = 1
   }
 }

--- a/modules/node-function-app/main.tf
+++ b/modules/node-function-app/main.tf
@@ -9,8 +9,8 @@ resource "azurerm_linux_function_app" "function_app" {
   public_network_access_enabled = !var.inbound_vnet_connectivity
 
   app_settings = merge(
-    var.app_settings,
-    local.app_settings
+    local.app_settings,
+    var.app_settings # passed in settings take precedence
   )
 
   dynamic "connection_string" {


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

Setting a default app setting for function apps:

`WEBSITE_RUN_FROM_PACKAGE=1`

This enables running from the zip package, and speeds up deployment times significantly. It's the recommended setting.
See https://learn.microsoft.com/en-gb/azure/azure-functions/run-functions-from-deployment-package

I also changed the merge order, so that app settings passed in can override the locals/defaults.

## Useful information to review or test

- Add any useful information that will help the reviewer test your changes.
- This could include example payloads, steps to reproduce, etc.

## Type of change 🧩

- [ ] Adding a new module
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] My code changes do not include any hardcoded secrets or passwords
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My Tech Lead is aware of any infrastructure changes that will cost money
