### PR TITLE
ci: fix tag-repo, to work with depth=1 fetch

### DIFF
--- a/release-automation/Tag-Repo.ps1
+++ b/release-automation/Tag-Repo.ps1
@@ -17,39 +17,44 @@ $tagInfoMajorVersion = [int]$tagInfoJson.major_version_number
 if ( ($SourceBranch -match "^[\d]*\.x$") -or ($SourceBranch -eq "main" ) ) {
     # Derive latest existing minor version and increment
     $commits = $(git --no-pager log --format="%H %D")
-    # write-host "Commits: $commits"
 
     $isLatestCommitTagged = ($commits[0] -like "*tag*") # string matches wildcard pattern
-    write-host "IsLatestCommit? $isLatestCommitTagged" # This is where the error is happening in the pipeline - stating False and then jumping to line 37. It is not picking up the latest commit and the HEAD is detached.
+    write-host "isLatestCommitTagged? $isLatestCommitTagged"
 
     if ( $isLatestCommitTagged ) {
-        write-output "Latest commit is already tagged - no work to do" # It is not the latest commit as this message would be read
-
-############ From here
+        write-output "Latest commit is already tagged - no work to do"
     } else {
-        $commitCounter = 0
-        foreach ($commit in $commits) {
-            if ($commit -match "^.*tag:\s(?<tag>[\d\.]*).*") {
+        # the repo is fetched with depth=1, so the commit history contains just one commit
+        # however we do fetch tags, so we just need to list them specifically
+        # example output:
+        # (grafted, tag: 1.11)
+        # (grafted, tag: 1.10)
+        # (grafted, tag: 1.9)
+        # ...
+        $tags = $(git log --tags --pretty="format:%d")
+        foreach ($tagLog in $tags) {
+            # all lines should include a tag, but we're also checking the tag is numbers (i.e. a version)
+            if ($tagLog -match "^.*tag:\s(?<tag>[\d\.]*).*") {
                 $existingVersion = $Matches.tag # matches contains last match values
                 break
             }
-            $commitCounter++
         }
         if (! $existingVersion) {
-            throw "There is no tagged commit on this branch. One needs to exist to derive next tag value" # can this error message be changed for the system to echo something itself?
+            throw "There is no tagged commit on this branch. One needs to exist to derive next tag value"
         }
-########## To here is where it is erroring...
 
         # Derive new version number
         write-host "ExistingVersion is $existingVersion"
         [int]$existingMajorVersion = (($existingVersion -split "\.")[0]).Trim() # get the first occurrence of a number
         [int]$existingMinorVersion = (($existingVersion -split "\.")[1]).Trim() # get the second occurrence of a number
 
+
         if ($tagInfoMajorVersion -gt $existingMajorVersion) {
             $newMajorVersion = $tagInfoMajorVersion
             $newMinorVersion = 0
 
             # Create branch from previous commit and push to remote
+            # this will likely fail for a new major version, we have no previous commit in history to branch from
             $previousCommit = ($commits[$commitCounter] -split "\s+")[0] # Gets full commit hash
             $branchName = "$existingMajorVersion.x"
             if ($Mode -eq $planModeValue) {
@@ -75,5 +80,5 @@ if ( ($SourceBranch -match "^[\d]*\.x$") -or ($SourceBranch -eq "main" ) ) {
         }
     }
 } else {
-    write-host "No work to do - this is not a commit on a branch that should be tagged" # saying that this commmit is irrelevant because it's not on a branch that should be tagged
+    write-host "No work to do - this is not a commit on a branch that should be tagged"
 }


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

Try to fix release tagging again. The issue was related to how the pipeline checks out the repo (it only pulls down one commit).

## Useful information to review or test

- Add any useful information that will help the reviewer test your changes.
- This could include example payloads, steps to reproduce, etc.

## Type of change 🧩

- [ ] Adding a new module
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] My code changes do not include any hardcoded secrets or passwords
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My Tech Lead is aware of any infrastructure changes that will cost money
