### PR TITLE
feat: add sticky slot settings

### DIFF
--- a/modules/node-app-service/README.md
+++ b/modules/node-app-service/README.md
@@ -67,6 +67,7 @@ No modules.
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group | `string` | n/a | yes |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | The suffix for resource naming | `string` | n/a | yes |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | The name of the service the app belongs to | `string` | n/a | yes |
+| <a name="input_slot_setting_overrides"></a> [slot\_setting\_overrides](#input\_slot\_setting\_overrides) | The environment variable names that should be different on slots, will be marked as sticky | `map(string)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | The tags applied to all resources | `map(string)` | n/a | yes |
 
 ## Outputs

--- a/modules/node-app-service/main.tf
+++ b/modules/node-app-service/main.tf
@@ -16,6 +16,14 @@ resource "azurerm_linux_web_app" "web_app" {
 
   app_settings = local.app_settings
 
+  dynamic "sticky_settings" {
+    for_each = length(var.slot_setting_overrides) > 0 ? [1] : []
+
+    content {
+      app_setting_names = keys(var.slot_setting_overrides)
+    }
+  }
+
   identity {
     type = "SystemAssigned"
   }
@@ -108,7 +116,7 @@ resource "azurerm_linux_web_app_slot" "staging" {
   client_certificate_enabled = false
   https_only                 = true
 
-  app_settings = local.app_settings
+  app_settings = merge(local.app_settings, var.slot_setting_overrides)
 
   identity {
     type = "SystemAssigned"

--- a/modules/node-app-service/variables.tf
+++ b/modules/node-app-service/variables.tf
@@ -37,6 +37,12 @@ variable "app_settings" {
   default     = {}
 }
 
+variable "slot_setting_overrides" {
+  description = "The environment variable names that should be different on slots, will be marked as sticky"
+  type        = map(string)
+  default     = {}
+}
+
 #EasyAuth setting
 variable "auth_config" {
   description = "Config for the Azure Easy Authentication"


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

Allow slot override map to be passed in for app service module
These will be set differently on the slot and be sticky so they do not switch when the slots are swapped

## Useful information to review or test

## Type of change 🧩

- [ ] Adding a new module
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] My code changes do not include any hardcoded secrets or passwords
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My Tech Lead is aware of any infrastructure changes that will cost money
