### PR TITLE
feat(node-app-service): add worker_count option

### DIFF
--- a/modules/node-app-service/main.tf
+++ b/modules/node-app-service/main.tf
@@ -45,6 +45,7 @@ resource "azurerm_linux_web_app" "web_app" {
     http2_enabled                     = true
     health_check_path                 = var.health_check_path
     health_check_eviction_time_in_min = var.health_check_eviction_time_in_min
+    worker_count                      = var.worker_count
 
     application_stack {
       docker_image_name        = "${var.image_name}:main"

--- a/modules/node-app-service/variables.tf
+++ b/modules/node-app-service/variables.tf
@@ -188,3 +188,10 @@ variable "tags" {
   description = "The tags applied to all resources"
   type        = map(string)
 }
+
+# see https://learn.microsoft.com/en-us/azure/app-service/manage-scale-per-app#recommended-configuration-for-high-density-hosting
+variable "worker_count" {
+  description = "The number of workers for the app service (when using per site scaling)"
+  type        = number
+  default     = null
+}


### PR DESCRIPTION
Add a worker_count variable to support per-site-scaling options: https://learn.microsoft.com/en-us/azure/app-service/manage-scale-per-app

