### PR TITLE
feat(node-function-app): add private endpoint support

### DIFF
--- a/modules/node-function-app/main.tf
+++ b/modules/node-function-app/main.tf
@@ -53,6 +53,29 @@ resource "azurerm_linux_function_app" "function_app" {
   }
 }
 
+resource "azurerm_private_endpoint" "private_endpoint" {
+  count = var.inbound_vnet_connectivity ? 1 : 0
+
+  name                = "pins-pe-${var.service_name}-${var.app_name}-${var.resource_suffix}"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.private_endpoint.subnet_id
+
+  private_dns_zone_group {
+    name                 = "appserviceprivatednszone"
+    private_dns_zone_ids = [var.private_endpoint.private_dns_zone_id]
+  }
+
+  private_service_connection {
+    name                           = "privateendpointconnection"
+    private_connection_resource_id = azurerm_linux_function_app.function_app.id
+    subresource_names              = ["sites"]
+    is_manual_connection           = false
+  }
+
+  tags = var.tags
+}
+
 # setup key vault read access if configured
 resource "azurerm_key_vault_access_policy" "read_secrets" {
   count = var.key_vault_id != null ? 1 : 0

--- a/modules/node-function-app/variables.tf
+++ b/modules/node-function-app/variables.tf
@@ -94,6 +94,15 @@ variable "outbound_vnet_connectivity" {
   type        = bool
 }
 
+variable "private_endpoint" {
+  description = "Configuration to use if using private endpoints (also set inbound_vnet_connectivity=true)"
+  default     = null
+  type = object({
+    subnet_id           = string
+    private_dns_zone_id = string
+  })
+}
+
 variable "resource_group_name" {
   description = "The name of the resource group"
   type        = string


### PR DESCRIPTION
Support private endpoints for function apps using the existing `inbound_vnet_connectivity` boolean plus some further config for the private endpoint itself